### PR TITLE
4 ramble service

### DIFF
--- a/app/entry.js
+++ b/app/entry.js
@@ -18,4 +18,4 @@ require('./service/ramble-service');
 // angular controllers
 require('./view/signup');
 require('./view/signin');
-require('./view/home');
+// require('./view/home');

--- a/app/entry.js
+++ b/app/entry.js
@@ -13,6 +13,7 @@ angular.module('ramble', []);
 
 // angular services
 require('./service/auth-service');
+require('./service/ramble-service');
 
 // angular controllers
 require('./view/signup');

--- a/app/service/auth-service.js
+++ b/app/service/auth-service.js
@@ -26,7 +26,7 @@ function authService($log, $q, $window, $http) {
     if (token) return $q.resolve(token);
     token = $window.localStorage.getItem('token');
 
-    if(token) return $q.resole(token);
+    if(token) return $q.resolve(token);
     return $q.reject(new Error('token not found'));
   };
 

--- a/app/service/ramble-service.js
+++ b/app/service/ramble-service.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const angular = require('angular');
+const ramble = angular.module('ramble');
+
+ramble.factory('rambleService' ['$log', '$q', '$http', 'authService', rambleService]);
+
+function rambleService($log, $q, $http, authService) {
+  let service = {};
+  let token = authService.getToken();
+
+  service.fetchEntries = function() {
+    if (!token) return $q.reject(new Error('no token -- not authorized'));
+    let url = `${__API_URL__}/api/entry`;
+    let config = {
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${token}`
+      }
+    };
+
+    return $http.get(url, config)
+    .then(res => {
+      $log.info('success -- entries ', res.data);
+      return $q.resolve(res.data);
+    })
+    .catch(err => {
+      $log.info('error -- entries ', err);
+      return $q.reject(err);
+    });
+  };
+
+  service.createEntry = function(entry) {
+    if (!token) return $q.reject(new Error('no token -- not authorized'));
+    let url = `${__API_URL__}/api/entry`;
+    let config = {
+      headers: {
+        'Accept': 'application/json',
+        'Authorization': `Bearer ${token}`
+      }
+    };
+
+    return $http.post(url, entry, config)
+    .then(res = {
+      $log.info('success -- entries ', res.data)
+      return $q.resolve(res.data)
+    })
+    .catch(err => {
+      $log.info('error -- entries ', err)
+      return $q.reject(err)
+    })
+  };
+
+  return service
+}

--- a/app/service/ramble-service.js
+++ b/app/service/ramble-service.js
@@ -3,7 +3,7 @@
 const angular = require('angular');
 const ramble = angular.module('ramble');
 
-ramble.factory('rambleService' ['$log', '$q', '$http', 'authService', rambleService]);
+ramble.factory('rambleService', ['$log', '$q', '$http', 'authService', rambleService]);
 
 function rambleService($log, $q, $http, authService) {
   let service = {};
@@ -11,7 +11,7 @@ function rambleService($log, $q, $http, authService) {
 
   service.fetchEntries = function() {
     if (!token) return $q.reject(new Error('no token -- not authorized'));
-    let url = `${__API_URL__}/api/entry`;
+    let url = `${__API_URL__}/api/entries`;
     let config = {
       headers: {
         'Accept': 'application/json',
@@ -41,15 +41,15 @@ function rambleService($log, $q, $http, authService) {
     };
 
     return $http.post(url, entry, config)
-    .then(res = {
-      $log.info('success -- entries ', res.data)
-      return $q.resolve(res.data)
+    .then(res => {
+      $log.info('success -- entries ', res.data);
+      return $q.resolve(res.data);
     })
     .catch(err => {
-      $log.info('error -- entries ', err)
-      return $q.reject(err)
-    })
+      $log.info('error -- entries ', err);
+      return $q.reject(err);
+    });
   };
 
-  return service
+  return service;
 }

--- a/app/view/signin/index.js
+++ b/app/view/signin/index.js
@@ -3,7 +3,7 @@
 require('./_signin.scss');
 
 const angular = require('angular');
-const ramble = angular.module(ramble);
+const ramble = angular.module('ramble');
 
 
 ramble.controller('SigninController', ['$log', '$location', 'authService', SigninController]);

--- a/test/ramble-service-test.js
+++ b/test/ramble-service-test.js
@@ -36,4 +36,27 @@ describe('testing ramble service', () => {
       expect(Array.isArray(res.data)).toBe(true);
     });
   });
+
+  it('should post an entry', () => {
+    const authString = this.authService.getToken();
+    const post = {id: 3, title: 'fake title three', keywords: ['key', 'word', 'three']};
+    const headers = {
+      'Accept':'application/json',
+      'Authorization': `Bearer ${authString}`,
+      'Content-Type':'application/json;charset=utf-8'
+    };
+
+    this.httpBackend.expectPOST(`${rambleTestUrl}/api/entry`, post, headers)
+    .respond(200, [
+      {id: 1, title: 'fake title', keywords: ['key', 'word']},
+      {id: 2, title: 'fake title two', keywords: ['key', 'two']},
+      {id: 3, title: 'fake title three', keywords: ['key', 'word', 'three']}
+    ]);
+
+    this.rambleService.createEntry(post)
+    .then(res => {
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.data)).toBe(true);
+    });
+  });
 });

--- a/test/ramble-service-test.js
+++ b/test/ramble-service-test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const rambleTestUrl = 'http://localhost:3000';
+
+describe('testing ramble service', () => {
+  beforeEach(() => {
+    angular.mock.module('ramble');
+    angular.mock.inject((rambleService, authService, $httpBackend) => {
+      this.authService = authService;
+      this.rambleService = rambleService;
+      this.httpBackend = $httpBackend;
+    });
+  });
+
+  afterEach(() => {
+    this.httpBackend.verifyNoOutstandingRequest();
+    this.httpBackend.verifyNoOutstandingExpectation();
+  });
+
+  it('should get some entries', () => {
+    const authString = this.authService.getToken();
+    const headers = {
+      'Accept':'application/json',
+      'Authorization': `Bearer ${authString}`
+    };
+
+    this.httpBackend.expectGET(`${rambleTestUrl}/api/entries`, headers)
+    .respond(200, [
+      {id: 1, title: 'fake title', keywords: ['key', 'word']},
+      {id: 2, title: 'fake title two', keywords: ['key', 'two']}
+    ]);
+
+    this.rambleService.fetchEntries()
+    .then(res => {
+      expect(res.status).toBe(200);
+      expect(Array.isArray(res.data)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Basic Ramble Service is up and running. Supports fetching all entries and creating a single entry.
Testing is working, but could probably be more robust.

Also found a small error `auth-service.js` --  (misspelt `resolve`) and in the `signin/index.js`