### PR TITLE
Issue #70: Add new post routing to Start New Post button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ramble
-<p>
-  Don't have an account? <a href="/#/signup">Sign up here!</a>
-</p>
+[![Stories in Ready](https://badge.waffle.io/ascasson/ramble.png?label=ready&title=Ready)](http://waffle.io/ascasson/ramble)
+
 # Front End (MVP)
 * Login / Signup -- `/signup` & `/signin`
 * View Entries -- `/dashboard`

--- a/app/component/nav/index.js
+++ b/app/component/nav/index.js
@@ -14,5 +14,9 @@ ramble.component('rambleNavBar', {
       authService.logout()
       .then(()=> $location.path('/signin'));
     };
+
+    this.newPost = function(){
+      $location.path('/new/post');
+    };
   }
 });

--- a/app/component/nav/nav.html
+++ b/app/component/nav/nav.html
@@ -2,6 +2,6 @@
   <div class="nav-bar-logo">
     <img src="asset/image/ramble-icon.png" alt="ramble icon" />
   </div>
-  <button type="button" name="button" class="create-new">Start New Post</button>
+  <button ng-click="$ctrl.newPost()" type="button" name="button" class="create-new">Start New Post</button>
   <button type="button" name="button" class="signout" ng-click="$ctrl.logout()">Sign Out</button>
 </nav>


### PR DESCRIPTION
I added a function that routes the user to '/new/post' when they click the 'Start New Post' button on the dashboard.